### PR TITLE
https for bioconductor.org

### DIFF
--- a/_settings/LocalSettings.php
+++ b/_settings/LocalSettings.php
@@ -260,7 +260,7 @@ $wgFooterIcons['poweredby']['cuny'] = [
 
 $wgFooterIcons['poweredby']['bioconductor'] = [
 	'src' => $wgScriptPath . '/bioc.png',
-	'url' => 'http://bioconductor.org/',
+	'url' => 'https://bioconductor.org/',
 	'alt' => 'Bioconductor - Open Source Software for Bioinformatics',
 	'width' => 'auto',
 	'height' => '48',


### PR DESCRIPTION
One small request, could you link to _https_ instead of _http_? bioconductor.org accepts both, so might as well use the secure link.