### PR TITLE
PageForms: fix bug with possible values

### DIFF
--- a/_resources/extensions/PageForms/includes/PF_FormField.php
+++ b/_resources/extensions/PageForms/includes/PF_FormField.php
@@ -548,7 +548,9 @@ class PFFormField {
 			return;
 		}
 
-		$this->mPossibleValues = $this->template_field->getPossibleValues();
+		if ( $this->mPossibleValues === null ) {
+			$this->mPossibleValues = $this->template_field->getPossibleValues();
+		}
 	}
 
 	function cleanupTranslateTags( &$value ) {


### PR DESCRIPTION
In PFFormField::setPossibleValues() use the template field's possible values as a fallback only if there are no current values set.

Fixes waldronlab/BugSigDB#188
MBSD-201