### PR TITLE
Echo: fix recursion in `EchoWatchlistChangePresentationModel::getEventTitle()`

### DIFF
--- a/_resources/extensions/Echo_patched_MBSD-230/includes/formatters/WatchlistChangePresentationModel.php
+++ b/_resources/extensions/Echo_patched_MBSD-230/includes/formatters/WatchlistChangePresentationModel.php
@@ -116,7 +116,7 @@ class EchoWatchlistChangePresentationModel extends EchoEventPresentationModel {
 	 * @return Title
 	 */
 	private function getEventTitle(): Title {
-		$title = $this->getEventTitle();
+		$title = $this->event->getTitle();
 		if ( !$title ) {
 			$pageId = $this->event->getPageId();
 			if ( $pageId ) {


### PR DESCRIPTION
Broken in updating our forked version of Echo for 1.39 but not noticed and fixed until now when it was causing issues with DiscussionTools.

WLDR-386