### PR TITLE
Update Taqasta to `1.39.13-20250930-db294b9`

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -21,7 +21,7 @@ services:
             - db_data:/var/lib/mysql
 
     web:
-        image: ghcr.io/wikiteq/taqasta:1.39.13-20250926-8bd8926 # BEFORE changing, make sure the PR https://github.com/WikiTeq/Taqasta/pull/264 was merged or MW version >= 1.43.1
+        image: ghcr.io/wikiteq/taqasta:1.39.13-20250930-db294b9 # BEFORE changing, make sure the PR https://github.com/WikiTeq/Taqasta/pull/264 was merged or MW version >= 1.43.1
         restart: unless-stopped
         extra_hosts:
             - "gateway.docker.internal:host-gateway"


### PR DESCRIPTION
Includes WikiTeq/Taqasta#307 which updates the Arrays extension to avoid warnings about undefined array keys

WLDR-415