### PR TITLE
Migrates Matomo to isolated database instance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 # Mandatory
 MYSQL_ROOT_PASSWORD=
+
+# Matomo (disabled by default), requires /matomo/ mount to be available
+COMPOSE_PROFILES=matomo
+MATOMO_MYSQL_ROOT_PASSWORD=
+MATOMO_MYSQL_PASSWORD=
 MATOMO_PASSWORD=
 
 # For production (optional for others)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Running `docker compose up -d` will start the containers:
 - `db` - MySQL [official container](https://hub.docker.com/_/mysql/), used as the database backend for MediaWiki.
 - `web` - Apache/MediaWiki container (Taqasta) with PHP 7.4 and MediaWiki 1.39.x
 - `redis` - Redis is an open-source key-value store used as the cache backend
-- `matomo` - [Matomo](https://matomo.org/) analytics instance
+  - `matomo` - [Matomo](https://matomo.org/) analytics instance (disabled by default, requires `matomo` profile to be set)
 - `elasticsearch` - Advanced search engine
 - `varnish` - A reverse caching proxy and HTTP accelerator
 - `restic` - (production only) Modern backup container performing incremental backups to both S3 storage and Google Cloud Storage (GCS)
@@ -50,6 +50,7 @@ If changed, ensure corresponding database passwords (`MW_DB_PASS` in the web sec
 
 #### environment variables
 
+- `COMPOSE_PROFILES` enables services with the selected profiles. Available profiles: `matomo`
 - `MW_SITE_SERVER` configures [$wgServer](https://www.mediawiki.org/wiki/Manual:$wgServer); set this to the server host and include the protocol like `https://bugsigdb.org`
 - `MW_SITE_NAME` configures [$wgSitename](https://www.mediawiki.org/wiki/Manual:$wgSitename)
 - `MW_SITE_LANG` configures [$wgLanguageCode](https://www.mediawiki.org/wiki/Manual:$wgLanguageCode)
@@ -93,6 +94,8 @@ Matomo instance provides website analytics:
 
 - Default admin username: `admin`
 - `MATOMO_PASSWORD` - sets the initial password for matomo administration panel
+- `MATOMO_MYSQL_ROOT_PASSWORD` - MySQL root password for matomo database
+- `MATOMO_MYSQL_PASSWORD` - MySQL user password for matomo database
 
 ### varnish
 
@@ -110,6 +113,10 @@ Varnish cache container used as reverse proxy and front-end cache server:
 ### Bind mounts
 Used to just binding a certain directory or file from the host inside the container. We use:
 - `./__initdb` directory is used to pass the database dump for stack initialization
+
+####  Matomo
+When `matomo` profile is enabled the stack expects you to have `/matomo/data` and `/matomo/__initdb` directories
+on the host.
 
 ### Named volumes
 Data that must be persistent across container life cycles are stored in docker volumes:

--- a/compose.yml
+++ b/compose.yml
@@ -20,6 +20,31 @@ services:
             - ./__initdb:/docker-entrypoint-initdb.d
             - db_data:/var/lib/mysql
 
+    matomo-db:
+        profiles:
+            - matomo
+        container_name: ${COMPOSE_PROJECT_NAME}_matomo_db # don't allow to scale the container
+        image: mysql:8.0
+        # MBSD-262
+        command: >
+            --default-authentication-plugin=mysql_native_password
+            --binlog_expire_logs_seconds=86400
+            --secure-file-priv=""
+            --local-infile=1
+            --innodb_redo_log_capacity=1G
+        cap_add:
+            - SYS_NICE  # CAP_SYS_NICE, fix error mbind: Operation not permitted
+        restart: unless-stopped
+        environment:
+            - MYSQL_DATABASE=matomo
+            - MYSQL_ROOT_HOST=%
+            - MYSQL_ROOT_PASSWORD=${MATOMO_MYSQL_ROOT_PASSWORD?Variable MATOMO_MYSQL_ROOT_PASSWORD not set}
+            - MYSQL_USER=matomo
+            - MYSQL_PASSWORD=${MATOMO_MYSQL_PASSWORD?Variable MATOMO_MYSQL_PASSWORD not set}
+        volumes:
+            - /matomo/__initdb:/docker-entrypoint-initdb.d
+            - /matomo/data:/var/lib/mysql
+
     web:
         image: ghcr.io/wikiteq/taqasta:1.39.13-20251009-6b3acda # BEFORE upgrading to 1.4x, make sure the PR https://github.com/WikiTeq/Taqasta/pull/264 was merged or MW version >= 1.43.1
         restart: unless-stopped
@@ -103,18 +128,20 @@ services:
             - elasticsearch_data:/usr/share/elasticsearch/data
 
     matomo:
+        profiles:
+            - matomo
         image: matomo:5.1.1
         restart: unless-stopped
         networks:
             - default
             - traefik-public
         depends_on:
-            - db
+            - matomo-db
         environment:
-            - MATOMO_DATABASE_HOST=db
+            - MATOMO_DATABASE_HOST=matomo-db
             - MATOMO_DATABASE_DBNAME=matomo
-            - MATOMO_DATABASE_USERNAME=root
-            - MATOMO_DATABASE_PASSWORD=${MYSQL_ROOT_PASSWORD?Variable MYSQL_ROOT_PASSWORD not set}
+            - MATOMO_DATABASE_USERNAME=matomo
+            - MATOMO_DATABASE_PASSWORD=${MATOMO_MYSQL_PASSWORD?Variable MATOMO_MYSQL_PASSWORD not set}
             - PHP_MEMORY_LIMIT=2G
         volumes:
             - matomo_data:/var/www/html


### PR DESCRIPTION
* Adds `matomo-db` service for database
* Adds `MATOMO_MYSQL_ROOT_PASSWORD` and `MATOMO_MYSQL_PASSWORD` envs
* Puts `matomo` and `matomo-db` services behind `matomo` profile
* Binds `/matomo/data` and `/matomo/__initdb` to the `matomo-db` service as volumes

Deployment algo:
* Stop & remove the matomo containers
* Pull the changes
* Update the `.env` (do not  forget to set `COMPOSE_PROFILES`)
* Ensure the matomo database dump is present at `/matomo/__initdb`
* Start the `matomo-db` service
* Wait for the dump to be imported
* Start the `matomo` service
