### PR TITLE
Update Taqasta to `1.39.13-20251027-29d45de`

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -46,7 +46,7 @@ services:
             - /matomo/data:/var/lib/mysql
 
     web:
-        image: ghcr.io/wikiteq/taqasta:1.39.13-20251021-c97a70f # BEFORE upgrading to 1.4x, make sure the PR https://github.com/WikiTeq/Taqasta/pull/264 was merged or MW version >= 1.43.1
+        image: ghcr.io/wikiteq/taqasta:1.39.13-20251027-29d45de # BEFORE upgrading to 1.4x, make sure the PR https://github.com/WikiTeq/Taqasta/pull/264 was merged or MW version >= 1.43.1
         restart: unless-stopped
         extra_hosts:
             - "gateway.docker.internal:host-gateway"


### PR DESCRIPTION
Includes WikiTeq/Taqasta#321 for fixing PubmedParser support for author names with multi-byte characters

WLDR-419