### PR TITLE
Stop using `MW_LOAD_EXTENSIONS` and `MW_LOAD_SKINS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ If changed, ensure corresponding database passwords (`MW_DB_PASS` in the web sec
 - `MW_SITE_SERVER` configures [$wgServer](https://www.mediawiki.org/wiki/Manual:$wgServer); set this to the server host and include the protocol like `https://bugsigdb.org`
 - `MW_SITE_NAME` configures [$wgSitename](https://www.mediawiki.org/wiki/Manual:$wgSitename)
 - `MW_SITE_LANG` configures [$wgLanguageCode](https://www.mediawiki.org/wiki/Manual:$wgLanguageCode)
-- `MW_DEFAULT_SKIN` configures [$wgDefaultSkin](https://www.mediawiki.org/wiki/Manual:$wgDefaultSkin)
 - `MW_ENABLE_UPLOADS` configures [$wgEnableUploads](https://www.mediawiki.org/wiki/Manual:$wgEnableUploads)
 - `MW_ADMIN_USER` configures the default administrator username
 - `MW_ADMIN_PASSWORD` configures the default administrator password
@@ -63,8 +62,6 @@ If changed, ensure corresponding database passwords (`MW_DB_PASS` in the web sec
 - `MW_DB_PASS` specifies the DB user password; must match your MySQL password
 - `MW_PROXY_SERVERS` configures [$wgSquidServers](https://www.mediawiki.org/wiki/Manual:$wgSquidServers) for reverse proxies (typically `varnish:80`)
 - `MW_MAIN_CACHE_TYPE` configures [$wgMainCacheType](https://www.mediawiki.org/wiki/Manual:$wgMainCacheType). (`CACHE_REDIS` is recommended)
-- `MW_LOAD_EXTENSIONS` provided as comma-separated list of MediaWiki extensions to load during container startup
-- `MW_LOAD_SKINS` comma-separated list of MediaWiki skins available for use
 - `MW_SEARCH_TYPE` configures the search backend (typically `CirrusSearch`)
 - `MW_NCBI_TAXONOMY_API_KEY`, `MW_RECAPTCHA_SITE_KEY`, `MW_RECAPTCHA_SECRET_KEY` optional/requested third-party API keys
 - `MW_ENABLE_SITEMAP_GENERATOR` enables sitemap generator script on production (`true/false`)

--- a/_settings/LocalSettings.php
+++ b/_settings/LocalSettings.php
@@ -88,6 +88,36 @@ $wgGroupPermissions['*']['edit'] = false;
 //$wgDefaultSkin = "chameleon";
 $wgCategoryCollation = 'numeric';
 
+wfLoadSkin( 'Vector' );
+wfLoadSkin( 'chameleon' );
+$wgDefaultSkin = 'chameleon';
+wfLoadExtension( 'Bootstrap' );
+
+wfLoadExtension( 'GTag' );
+wfLoadExtension( 'CodeEditor' );
+wfLoadExtension( 'Nuke' );
+wfLoadExtension( 'ParserFunctions' );
+wfLoadExtension( 'ReplaceText' );
+wfLoadExtension( 'WikiEditor' );
+wfLoadExtension( 'Interwiki' );
+wfLoadExtension( 'CodeEditor' );
+wfLoadExtension( 'Scribunto' );
+wfLoadExtension( 'SyntaxHighlight_GeSHi' );
+wfLoadExtension( 'DataTransfer' );
+wfLoadExtension( 'Variables' );
+wfLoadExtension( 'PubmedParser' );
+wfLoadExtension( 'CodeMirror' );
+wfLoadExtension( 'Loops' );
+wfLoadExtension( 'MyVariables' );
+wfLoadExtension( 'Arrays' );
+wfLoadExtension( 'DisplayTitle' );
+wfLoadExtension( 'NCBITaxonomyLookup' );
+wfLoadExtension( 'SemanticExtraSpecialProperties' );
+wfLoadExtension( 'SemanticResultFormats' );
+
+$wgScribuntoUseGeSHi = true;
+$wgScribuntoUseCodeEditor = true;
+
 //# Enabled skins.
 //# The following skins were automatically enabled:
 //wfLoadSkin( 'Vector' );

--- a/compose.yml
+++ b/compose.yml
@@ -68,9 +68,6 @@ services:
             - MW_SITE_LANG=en
             - MW_ENABLE_UPLOADS=1
             - MW_MAIN_CACHE_TYPE=CACHE_REDIS
-            - MW_LOAD_SKINS=Vector,chameleon
-            - MW_DEFAULT_SKIN=chameleon
-            - MW_LOAD_EXTENSIONS=GTag,CodeEditor,Nuke,ParserFunctions,ReplaceText,WikiEditor,Interwiki,CodeEditor,Scribunto,SyntaxHighlight_GeSHi,DataTransfer,Variables,PubmedParser,CodeMirror,Loops,MyVariables,Arrays,DisplayTitle,NCBITaxonomyLookup,SemanticExtraSpecialProperties,SemanticResultFormats
             - MW_SEARCH_TYPE=CirrusSearch
             - MW_PROXY_SERVERS=varnish:80
             - MW_CACHE_PURGE_PAUSE=3600


### PR DESCRIPTION
Load extensions previously loaded by `MW_LOAD_EXTENSIONS` manually in LocalSettings.php

* The settings `$wgScribuntoUseGeSHi` and `$wgScribuntoUseCodeEditor` were previously set based on whether the syntax highlighting and CodeEditor extensions were enabled via `MW_LOAD_EXTENSIONS`; now that they are enabled manually, set both configuration values to true.
* Local testing confirms that all of the extensions can be loaded via `wfLoadExtension()` rather than from a PHP entrypoint.

Load skins previously loaded by `MW_LOAD_SKINS` manually in LocalSettings.php

* Taqasta automatically enabled the `Bootstrap` extension when the `chameleon` skin was loaded via `MW_LOAD_SKINS`; now that the skin is manually loaded, the extension needs to be manually loaded as well.
* Taqasta automatically sets `$wgDefaultSkin` to `Vector` when `MW_LOAD_SKINS` is not used, even in the presence of of `MW_DEFAULT_SKIN`. Accordingly, manually set `$wgDefaultSkin` back to `chameleon`. To avoid confusion about the default skin being set in two places, also remove `MW_DEFAULT_SKIN`.

MBSD-375