### PR TITLE
Varnish: synthesize 405 for unknown HTTP methods

### DIFF
--- a/_resources/varnish/default.vcl
+++ b/_resources/varnish/default.vcl
@@ -35,13 +35,13 @@ sub vcl_recv {
             }
         }
 
-        # Pass any requests that Varnish does not understand straight to the backend.
-        if (req.method != "GET" && req.method != "HEAD" &&
-            req.method != "PUT" && req.method != "POST" &&
-            req.method != "TRACE" && req.method != "OPTIONS" &&
-            req.method != "DELETE") {
-                return (pipe);
-        } /* Non-RFC2616 or CONNECT which is weird. */
+        # Reject non-standard HTTP methods at the edge (no TCP tunnel to backend).
+        # Allowlist rationale (MediaWiki only):
+        # - OPTIONS: browser CORS preflight for cross-origin calls to api.php / rest.php (/w/rest.php/...).
+        # - PUT, PATCH, DELETE: used by some MediaWiki REST routes (/w/rest.php/...); not TRACE (unused, XST risk).
+        if (req.method !~ "^(GET|HEAD|PUT|POST|PATCH|DELETE|OPTIONS)$") {
+            return (synth(405, "Method Not Allowed"));
+        }
 
         # Pass anything other than GET and HEAD directly.
         if (req.method != "GET" && req.method != "HEAD") {
@@ -105,15 +105,6 @@ sub vcl_purge {
 #        }
 #        return (restart);
 #    }
-}
-
-sub vcl_pipe {
-    # Note that only the first request to the backend will have
-    # X-Forwarded-For set.  If you use X-Forwarded-For and want to
-    # have it set for all requests, make sure to have:
-    # set req.http.connection = "close";
-    # This is otherwise not necessary if you do not do any request rewriting.
-    set req.http.connection = "close";
 }
 
 # Called after a document has been successfully retrieved from the backend.


### PR DESCRIPTION
Replace pipe with edge 405; remove vcl_pipe. Allow GET, HEAD, PUT, POST, PATCH, DELETE, OPTIONS only.

OPTIONS: CORS preflight for cross-origin requests to MediaWiki API and REST (/w/rest.php/...).

PUT, PATCH, DELETE: used by some MediaWiki REST routes (/w/rest.php/...).

[MBSD-408]